### PR TITLE
Fix block mining and placing alignment issues

### DIFF
--- a/TesselBox-game-main/cmd/main.go
+++ b/TesselBox-game-main/cmd/main.go
@@ -126,7 +126,7 @@ func NewGame() *Game {
 
 	g := &Game{
 		world:         world.NewWorld("default"), // Default world name
-		player:        player.NewPlayer(0, 0), // Temporary position, will be updated
+		player:        player.NewPlayer(0, 0),    // Temporary position, will be updated
 		inventory:     items.NewInventory(32),
 		selectedBlock: "dirt", // Default to dirt in creative mode
 		CreativeMode:  true,   // Enable creative mode by default
@@ -137,7 +137,8 @@ func NewGame() *Game {
 	}
 
 	// Find a suitable spawn position and set player position
-	spawnX, spawnY := g.world.FindSpawnPosition(0, 0)
+	// Spawn in area where terrain is actually generated (negative coordinates)
+	spawnX, spawnY := g.world.FindSpawnPosition(-2000, -2000)
 	g.player.SetPosition(spawnX, spawnY)
 
 	// Initialize crafting system
@@ -218,6 +219,9 @@ func (g *Game) Update() error {
 		// Update player with delta time (framerate-independent)
 		g.player.Update(deltaTime)
 
+		// Update mining progress
+		g.updateMining(deltaTime)
+
 		// Update day/night cycle
 		g.dayNightCycle.Update()
 
@@ -266,9 +270,10 @@ func (g *Game) handleMenuAction(action menu.MenuAction) {
 	case menu.ActionStartGame:
 		g.inMenu = false
 		g.inGame = true
-		
+
 		// Find a suitable spawn position and set player position
-		spawnX, spawnY := g.world.FindSpawnPosition(0, 0)
+		// Spawn in area where terrain is actually generated (negative coordinates)
+		spawnX, spawnY := g.world.FindSpawnPosition(-2000, -2000)
 		g.player.SetPosition(spawnX, spawnY)
 		g.player.SetVelocity(0, 0)
 
@@ -383,6 +388,11 @@ func (g *Game) handleGameInput() {
 	// Start mining when left mouse button is pressed
 	if inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonLeft) {
 		g.startMining()
+	}
+
+	// Stop mining when left mouse button is released
+	if inpututil.IsMouseButtonJustReleased(ebiten.MouseButtonLeft) {
+		g.player.StopMining()
 	}
 
 	// Block placement with right click (only when not attacking)
@@ -594,9 +604,10 @@ func (g *Game) startMining() {
 	mouseWorldX := float64(g.mouseX) + g.cameraX
 	mouseWorldY := float64(g.mouseY) + g.cameraY
 
-	// Find the hexagon at mouse position
+	// Find hexagon at mouse position
 	targetHex := g.world.GetHexagonAt(mouseWorldX, mouseWorldY)
 	if targetHex == nil || targetHex.BlockType == blocks.AIR {
+		log.Printf("Mining failed: No block found at (%.1f,%.1f)", mouseWorldX, mouseWorldY)
 		return
 	}
 
@@ -604,16 +615,27 @@ func (g *Game) startMining() {
 	blockKey := getBlockKeyFromType(targetHex.BlockType)
 	blockDef := blocks.BlockDefinitions[blockKey]
 	if blockDef != nil && blockDef.Hardness <= 0 {
+		log.Printf("Mining failed: Block is unbreakable (%s)", blockKey)
 		return // Cannot mine unbreakable blocks
 	}
 
-	// Check if player can reach the block
+	// Check if player can reach
 	if !g.player.CanReach(targetHex.X, targetHex.Y) {
+		log.Printf("Mining failed: Block out of reach (%.1f,%.1f) distance=%.1f range=%.1f",
+			targetHex.X, targetHex.Y, math.Sqrt(g.player.DistanceTo(targetHex.X, targetHex.Y)), g.player.GetMiningRange())
 		return
 	}
 
-	// Instantly destroy the block in creative mode
-	g.completeMining(targetHex)
+	log.Printf("Mining started: %s at (%.1f,%.1f)", blockKey, targetHex.X, targetHex.Y)
+
+	// Start mining - let's update system handle completion
+	g.player.StartMining(targetHex)
+
+	// In creative mode, instantly destroy the block
+	if g.CreativeMode {
+		g.completeMining(targetHex)
+		g.player.StopMining()
+	}
 }
 
 // updateMining updates mining progress and handles block destruction
@@ -636,7 +658,7 @@ func (g *Game) updateMining(deltaTime float64) {
 		return // Cannot mine unbreakable blocks
 	}
 
-	// Calculate mining speed based on tool and block
+	// Calculate mining speed based on tool and block hardness
 	miningSpeed := g.calculateMiningSpeed(targetHex.BlockType)
 
 	// Update mining progress
@@ -787,22 +809,37 @@ func (g *Game) handleBlockPlacement() {
 	mouseWorldX := float64(g.mouseX) + g.cameraX
 	mouseWorldY := float64(g.mouseY) + g.cameraY
 
-	// Use the correct world position for placement
-	centerX, centerY, _, _ := world.PixelToHexCenter(mouseWorldX, mouseWorldY)
+	// Find the target hexagon at mouse position
+	targetHex := g.world.GetHexagonAt(mouseWorldX, mouseWorldY)
+
+	// Determine placement position based on target
+	var placeX, placeY float64
+
+	if targetHex != nil && targetHex.BlockType != blocks.AIR {
+		// Target is a block - place adjacent to it
+		// Find the nearest empty adjacent hex
+		placeX, placeY = g.findAdjacentEmptyPosition(targetHex.X, targetHex.Y, mouseWorldX, mouseWorldY)
+		if placeX == 0 && placeY == 0 {
+			return // No valid adjacent position found
+		}
+	} else {
+		// Target is empty air - try to place there
+		placeX, placeY = mouseWorldX, mouseWorldY
+	}
 
 	// Placement validation: check if position is valid
-	if !g.canPlaceBlockAt(centerX, centerY) {
+	if !g.canPlaceBlockAt(placeX, placeY) {
 		return // Cannot place block here
 	}
 
 	// Check if player can reach the block placement position
-	if !g.player.CanReach(centerX, centerY) {
+	if !g.player.CanReach(placeX, placeY) {
 		return
 	}
 
 	// Place block at the calculated position
 	blockType := stringToBlockType(blockTypeToPlace)
-	g.world.AddHexagonAt(centerX, centerY, blockType)
+	g.world.AddHexagonAt(placeX, placeY, blockType)
 
 	// Remove item from inventory only if not in creative mode
 	if !g.CreativeMode {
@@ -810,22 +847,74 @@ func (g *Game) handleBlockPlacement() {
 	}
 }
 
+// findAdjacentEmptyPosition finds the nearest empty hexagon adjacent to the given position
+func (g *Game) findAdjacentEmptyPosition(blockX, blockY, mouseX, mouseY float64) (float64, float64) {
+	// Get all adjacent hexagon positions
+	adjacentPositions := []struct {
+		q, r int
+	}{
+		{1, 0}, {1, -1}, {0, -1}, {-1, 0}, {-1, 1}, {0, 1}, // Hexagonal neighbors
+	}
+
+	// Convert target block position to hex coordinates
+	q, r := hexagon.PixelToHex(blockX, blockY, world.HexSize)
+	targetHex := hexagon.HexRound(q, r)
+
+	// Find the closest adjacent position to the mouse
+	var bestX, bestY float64
+	minDistance := math.MaxFloat64
+
+	for _, adj := range adjacentPositions {
+		// Calculate adjacent hex coordinates
+		adjHex := hexagon.Hexagon{
+			Q: targetHex.Q + adj.q,
+			R: targetHex.R + adj.r,
+		}
+
+		// Convert to world coordinates
+		adjX, adjY := hexagon.HexToPixel(adjHex, world.HexSize)
+
+		// Check if position is empty and valid for placement
+		if g.canPlaceBlockAt(adjX, adjY) {
+			// Calculate distance to mouse position
+			dx := adjX - mouseX
+			dy := adjY - mouseY
+			distance := math.Sqrt(dx*dx + dy*dy)
+
+			if distance < minDistance {
+				minDistance = distance
+				bestX = adjX
+				bestY = adjY
+			}
+		}
+	}
+
+	if minDistance == math.MaxFloat64 {
+		return 0, 0 // No valid position found
+	}
+
+	return bestX, bestY
+}
+
 // canPlaceBlockAt checks if a block can be placed at the given position
 func (g *Game) canPlaceBlockAt(x, y float64) bool {
 	// Check if there's already a block at this position
 	existingHex := g.world.GetHexagonAt(x, y)
 	if existingHex != nil {
+		log.Printf("Cannot place: Block already exists at (%.1f,%.1f)", x, y)
 		return false // Cannot place on existing block
 	}
 
 	// Check if player is too close (prevent placing blocks inside player)
-	// playerCenterX, playerCenterY := g.player.GetCenter()
-	// distance := math.Sqrt((x-playerCenterX)*(x-playerCenterX) + (y-playerCenterY)*(y-playerCenterY))
-	// minDistance := g.player.Width + world.HexSize
-	// if distance < minDistance {
-	// 	return false // Too close to player
-	// }
+	playerCenterX, playerCenterY := g.player.GetCenter()
+	distance := math.Sqrt((x-playerCenterX)*(x-playerCenterX) + (y-playerCenterY)*(y-playerCenterY))
+	minDistance := g.player.Width/2 + 10 // Much smaller buffer - just prevent overlap
+	if distance < minDistance {
+		log.Printf("Cannot place: Too close to player (%.1f < %.1f)", distance, minDistance)
+		return false // Too close to player
+	}
 
+	log.Printf("Position validation passed at (%.1f,%.1f)", x, y)
 	return true
 }
 

--- a/TesselBox-game-main/pkg/player/player.go
+++ b/TesselBox-game-main/pkg/player/player.go
@@ -13,7 +13,7 @@ const (
 	Friction     = 0.85
 	TerminalVelX = 300.0
 	TerminalVelY = 1200.0 // Increased for faster falling
-	MiningRange  = 150.0
+	MiningRange  = 300.0  // Increased mining range for better usability
 	PlayerWidth  = 40.0
 	PlayerHeight = 40.0 // Square player
 )

--- a/TesselBox-game-main/pkg/world/chunk.go
+++ b/TesselBox-game-main/pkg/world/chunk.go
@@ -53,18 +53,17 @@ func (c *Chunk) GetWorldPosition() (float64, float64) {
 
 // GetHexagon returns the hexagon at the given world coordinates
 func (c *Chunk) GetHexagon(x, y float64) *Hexagon {
-	// Use PixelToHexCenter to get accurate hexagon coordinates
-	centerX, centerY, _, _ := PixelToHexCenter(x, y)
-
 	worldX, worldY := c.GetWorldPosition()
 
-	// Calculate local row and column from center coordinates
-	localRow := int((centerY - worldY) / HexVSpacing)
-	localCol := int((centerX - worldX - HexWidth/2) / HexWidth)
+	// Calculate local row using same logic as AddHexagon
+	localRow := int((y - worldY) / HexVSpacing)
+
+	// Calculate local column with proper offset for interlocking (same as AddHexagon)
+	localCol := int((x - worldX - HexWidth/2) / HexWidth)
 	if localRow%2 == 0 {
-		localCol = int((centerX - worldX - HexWidth/2) / HexWidth)
+		localCol = int((x - worldX - HexWidth/2) / HexWidth)
 	} else {
-		localCol = int((centerX - worldX) / HexWidth)
+		localCol = int((x - worldX) / HexWidth)
 	}
 
 	key := [2]int{localCol, localRow}

--- a/TesselBox-game-main/pkg/world/world.go
+++ b/TesselBox-game-main/pkg/world/world.go
@@ -2,6 +2,7 @@ package world
 
 import (
 	"fmt"
+	"log"
 	"math"
 	"math/rand"
 	"time"
@@ -385,21 +386,50 @@ func (w *World) GetNearbyHexagons(x, y, radius float64) []*Hexagon {
 	return hexagons
 }
 
-// GetHexagonAt returns the hexagon at the given world position
+// GetHexagonAt returns the hexagon at the given world position with tolerance
 func (w *World) GetHexagonAt(x, y float64) *Hexagon {
 	chunkX, chunkY := w.GetChunkCoords(x, y)
 	chunk := w.GetChunk(chunkX, chunkY)
-	return chunk.GetHexagon(x, y)
+
+	// First try exact position
+	hex := chunk.GetHexagon(x, y)
+	if hex != nil {
+		return hex
+	}
+
+	// If no exact match, search nearby hexagons within tolerance
+	tolerance := 30.0 // pixels - roughly half hexagon size
+	nearbyHexagons := w.GetNearbyHexagons(x, y, tolerance)
+
+	var closestHex *Hexagon
+	minDistance := math.MaxFloat64
+
+	for _, nearbyHex := range nearbyHexagons {
+		dx := nearbyHex.X - x
+		dy := nearbyHex.Y - y
+		distance := math.Sqrt(dx*dx + dy*dy)
+
+		if distance < minDistance {
+			minDistance = distance
+			closestHex = nearbyHex
+		}
+	}
+
+	return closestHex
 }
 
 // AddHexagonAt adds a hexagon at the given world position
 func (w *World) AddHexagonAt(x, y float64, blockType blocks.BlockType) {
-	centerX, centerY, _, _ := PixelToHexCenter(x, y)
-	hexagon := NewHexagon(centerX, centerY, HexSize, blockType)
+	// Use the coordinates directly - don't convert to center
+	hexagon := NewHexagon(x, y, HexSize, blockType)
 
-	chunkX, chunkY := w.GetChunkCoords(centerX, centerY)
+	chunkX, chunkY := w.GetChunkCoords(x, y)
 	chunk := w.GetChunk(chunkX, chunkY)
-	chunk.AddHexagon(centerX, centerY, hexagon)
+
+	log.Printf("AddHexagonAt: placing at (%.1f,%.1f) -> chunk(%d,%d) -> type=%d",
+		x, y, chunkX, chunkY, blockType)
+
+	chunk.AddHexagon(x, y, hexagon)
 
 	// Add to spatial hash
 	w.addHexagonToSpatialHash(hexagon)
@@ -666,7 +696,7 @@ func (w *World) FindSpawnPosition(centerX, centerY float64) (float64, float64) {
 	// Search radius for finding suitable spawn
 	searchRadius := 500.0
 	stepSize := 50.0
-	
+
 	// Check in a spiral pattern around the center
 	for radius := 0.0; radius <= searchRadius; radius += stepSize {
 		if radius == 0 {
@@ -681,27 +711,27 @@ func (w *World) FindSpawnPosition(centerX, centerY float64) (float64, float64) {
 				angle := float64(i) / float64(steps) * 2 * math.Pi
 				checkX := centerX + math.Cos(angle)*radius
 				checkY := centerY + math.Sin(angle)*radius
-				
+
 				if spawnX, spawnY := w.checkPositionForSpawn(checkX, checkY); spawnX != 0 || spawnY != 0 {
 					return spawnX, spawnY
 				}
 			}
 		}
 	}
-	
+
 	// Fallback: generate terrain at center position and return guaranteed safe spawn
 	w.GetChunksInRange(centerX, centerY)
-	
+
 	// Find ground level at center position
 	var groundY float64 = centerY + 400 // Start searching from typical terrain height
-	for checkY := centerY + 300; checkY <= centerY + 600; checkY += 10.0 {
+	for checkY := centerY + 300; checkY <= centerY+600; checkY += 10.0 {
 		hex := w.GetHexagonAt(centerX, checkY)
 		if hex != nil && hex.BlockType != blocks.AIR {
 			groundY = checkY
 			break
 		}
 	}
-	
+
 	return centerX, groundY - 50 // Spawn 50 pixels above ground
 }
 
@@ -709,20 +739,20 @@ func (w *World) FindSpawnPosition(centerX, centerY float64) (float64, float64) {
 func (w *World) checkPositionForSpawn(x, y float64) (float64, float64) {
 	// Ensure chunks are loaded around this position
 	w.GetChunksInRange(x, y)
-	
+
 	// Check for solid ground below this position
 	// Look for a solid block within a reasonable distance below (based on world generation heights)
 	maxGroundCheck := 600.0 // Up to ocean depth
 	minGroundCheck := 300.0 // Start around typical terrain height
-	
-	for checkY := y + minGroundCheck; checkY <= y + maxGroundCheck; checkY += 10.0 {
+
+	for checkY := y + minGroundCheck; checkY <= y+maxGroundCheck; checkY += 10.0 {
 		hex := w.GetHexagonAt(x, checkY)
 		if hex != nil && hex.BlockType != blocks.AIR {
 			// Found solid ground, spawn 50 pixels above it
 			return x, checkY - 50
 		}
 	}
-	
+
 	// No suitable ground found
 	return 0, 0
 }


### PR DESCRIPTION
- Fixed coordinate system mismatch between storage and retrieval
- Increased mining range from 150 to 300 pixels for better usability
- Added tolerance to GetHexagonAt to find nearest hexagon when clicking between hexes
- Fixed spawn position to be where terrain actually exists (-2000, -2000)
- Reduced minimum distance for block placement to be less restrictive
- Fixed AddHexagonAt to use direct coordinates instead of PixelToHexCenter conversion
- Added proper creative vs survival mode handling for mining
- Added mouse button release handling to stop mining
- Enhanced block placement with smart adjacent positioning and validation

Resolves issues where blocks appeared randomly unmineable and placement wasn't working correctly.