### PR TITLE
Implement Randomland Dimension system

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,6 +23,7 @@ import (
 	"tesselbox/pkg/combat"
 	"tesselbox/pkg/crafting"
 	"tesselbox/pkg/debug"
+	"tesselbox/pkg/dimension"
 	"tesselbox/pkg/enemies"
 	"tesselbox/pkg/equipment"
 	"tesselbox/pkg/gametime"
@@ -294,6 +295,9 @@ type Game struct {
 	// Layer system (surface=0, middle=1, back=2)
 	currentLayer int
 	totalLayers  int
+
+	// Dimension system
+	dimensionManager *dimension.Manager
 }
 
 // NewGame creates a new game with default world
@@ -594,6 +598,14 @@ func NewGameWithWorld(worldName string, worldSeed int64) *Game {
 	g.totalLayers = 3
 	log.Printf("Layer system initialized: surface=0, middle=1, back=2")
 
+	// Initialize dimension system
+	storageDir := filepath.Join(getTesselboxDir(), "saves", worldName)
+	g.dimensionManager = dimension.NewManager(g.world, storageDir)
+	if err := g.dimensionManager.Load(); err != nil {
+		log.Printf("No saved dimension state found, starting fresh: %v", err)
+	}
+	log.Printf("Dimension system initialized")
+
 	log.Printf("Survival systems initialized: Equipment slots filled, wings equipped, HUD ready")
 
 	// Start in game mode (no menu)
@@ -801,6 +813,14 @@ func (g *Game) Update() error {
 			}
 			return false
 		})
+
+		// Update dimension system (zombie updates in randomland)
+		if g.dimensionManager != nil {
+			g.dimensionManager.Update(g.player, deltaTime)
+		}
+
+		// Check for portal teleportation
+		g.handlePortalTeleportation()
 
 		// Update camera to follow player
 		centerX, centerY = g.player.GetCenter()
@@ -2301,10 +2321,43 @@ func (g *Game) drawUI(screen *ebiten.Image) {
 		placementInstructions := "Right Click to place, Left Click to break"
 		ebitenutil.DebugPrintAt(screen, placementInstructions, 10, ScreenHeight-60)
 	}
+
+	// Draw portal interaction prompt
+	g.drawPortalPrompt(screen)
+}
+
+// drawPortalPrompt shows prompt when near a portal
+func (g *Game) drawPortalPrompt(screen *ebiten.Image) {
+	if g.dimensionManager == nil {
+		return
+	}
+
+	var promptText string
+	if g.dimensionManager.IsInRandomland() {
+		// In Randomland - check if near return portal
+		if g.dimensionManager.CheckReturnPortalProximity(g.player) {
+			promptText = "Press E to return to Overworld"
+		}
+	} else {
+		// In overworld - check if standing on portal
+		px, py := g.player.GetCenter()
+		hex := g.world.GetHexagonAt(px, py)
+		if hex != nil && hex.BlockType == blocks.RANDOMLAND_PORTAL {
+			promptText = "Press E to enter Randomland"
+		}
+	}
+
+	if promptText != "" {
+		// Draw at center of screen
+		x := ScreenWidth/2 - 80
+		y := ScreenHeight/2 + 50
+		ebitenutil.DebugPrintAt(screen, promptText, x, y)
+	}
 }
 
 // drawDebugInfo draws debug information
 func (g *Game) drawDebugInfo(screen *ebiten.Image) {
+	// ... (rest of the code remains the same)
 	px, py := g.player.GetCenter()
 	vx, vy := g.player.GetVelocity()
 
@@ -2319,9 +2372,15 @@ func (g *Game) drawDebugInfo(screen *ebiten.Image) {
 	layerNames := []string{"surface", "middle", "back"}
 	layerInfo := fmt.Sprintf("Layer: %s (%d/%d)", layerNames[g.currentLayer], g.currentLayer, g.totalLayers-1)
 
-	info := fmt.Sprintf("Pos: (%.1f, %.1f)\nVel: (%.1f, %.1f)\nFPS: %.1f\nOnGround: %v\nDelta: %.4f\n%s\n%s\n%s\n%s",
+	// Dimension info
+	dimensionInfo := "Dimension: Overworld"
+	if g.dimensionManager != nil && g.dimensionManager.IsInRandomland() {
+		dimensionInfo = "Dimension: Randomland"
+	}
+
+	info := fmt.Sprintf("Pos: (%.1f, %.1f)\nVel: (%.1f, %.1f)\nFPS: %.1f\nOnGround: %v\nDelta: %.4f\n%s\n%s\n%s\n%s\n%s",
 		px, py, vx, vy, ebiten.ActualFPS(), g.player.IsOnGround(), time.Since(g.lastTime).Seconds(),
-		timeInfo, lightInfo, weatherInfo, layerInfo)
+		timeInfo, lightInfo, weatherInfo, layerInfo, dimensionInfo)
 
 	ebitenutil.DebugPrint(screen, info)
 }
@@ -2602,9 +2661,24 @@ func (g *Game) drawPlayer(screen *ebiten.Image) {
 	}
 }
 
-// drawZombies draws all active zombies
+// drawZombies draws all active zombies (overworld and randomland)
 func (g *Game) drawZombies(screen *ebiten.Image) {
-	for _, zombie := range g.zombieSpawner.Zombies {
+	// Collect zombies from both spawners
+	var allZombies []*enemies.Zombie
+
+	// Add overworld zombies
+	if g.zombieSpawner != nil {
+		allZombies = append(allZombies, g.zombieSpawner.Zombies...)
+	}
+
+	// Add Randomland zombies if in that dimension
+	if g.dimensionManager != nil && g.dimensionManager.IsInRandomland() {
+		if g.dimensionManager.RandomlandDim != nil && g.dimensionManager.RandomlandDim.ZombieSpawner != nil {
+			allZombies = append(allZombies, g.dimensionManager.RandomlandDim.ZombieSpawner.Zombies...)
+		}
+	}
+
+	for _, zombie := range allZombies {
 		if !zombie.IsAlive {
 			continue
 		}
@@ -4027,6 +4101,51 @@ func deleteWorldCLI() {
 	}
 
 	fmt.Printf("World '%s' deleted successfully!\n", worldName)
+}
+
+// handlePortalTeleportation checks for and handles portal teleportation
+func (g *Game) handlePortalTeleportation() {
+	if g.dimensionManager == nil {
+		return
+	}
+
+	// Check if in Randomland and near return portal
+	if g.dimensionManager.IsInRandomland() {
+		if g.dimensionManager.CheckReturnPortalProximity(g.player) {
+			// Show prompt for return
+			// For now, auto-teleport when near return portal for testing
+			// TODO: Add prompt UI and require E key press
+			if inpututil.IsKeyJustPressed(ebiten.KeyE) {
+				// Save randomland state before leaving
+				if err := g.dimensionManager.Save(); err != nil {
+					log.Printf("Failed to save dimension state: %v", err)
+				}
+				// Teleport back to overworld
+				g.dimensionManager.TeleportToOverworld(g.player)
+				// Update world reference
+				g.world = g.dimensionManager.GetCurrentWorld()
+				log.Printf("Returned to overworld from Randomland")
+			}
+		}
+		return
+	}
+
+	// In overworld - check if standing on portal block
+	px, py := g.player.GetCenter()
+	hex := g.world.GetHexagonAt(px, py)
+	if hex != nil && hex.BlockType == blocks.RANDOMLAND_PORTAL {
+		// Check for activation key (E)
+		if inpututil.IsKeyJustPressed(ebiten.KeyE) {
+			// Teleport to Randomland
+			if err := g.dimensionManager.TeleportToRandomland(g.player); err != nil {
+				log.Printf("Failed to teleport to Randomland: %v", err)
+				return
+			}
+			// Update world reference to randomland
+			g.world = g.dimensionManager.GetCurrentWorld()
+			log.Printf("Teleported to Randomland!")
+		}
+	}
 }
 
 // cleanupAudio cleans up audio resources when shutting down

--- a/pkg/blocks/blocks.go
+++ b/pkg/blocks/blocks.go
@@ -94,6 +94,7 @@ const (
 	MOSSY_COBBLESTONE
 	STONE_BRICKS
 	CHISELED_STONE
+	RANDOMLAND_PORTAL
 )
 
 // BlockProperties defines the properties of a block type
@@ -1059,6 +1060,19 @@ func loadDefaultBlocks() {
 				{80, 80, 80, 255},    // Wet: dark gray mossy cobblestone
 			},
 			HumidityPatterns: []string{"rough", "weathered", "mossy"},
+		},
+		"randomland_portal": {
+			ID:                   RANDOMLAND_PORTAL,
+			Name:                 "Randomland Portal",
+			Color:                color.RGBA{147, 0, 211, 255}, // Purple
+			Hardness:             -1,                           // Unbreakable
+			Transparent:          true,
+			Solid:                true,
+			Collectible:          true,
+			Flammable:            false,
+			LightLevel:           15, // Full brightness
+			Gravity:              false,
+			HasHumidityVariation: false,
 		},
 	}
 

--- a/pkg/crafting/crafting.go
+++ b/pkg/crafting/crafting.go
@@ -461,6 +461,24 @@ func (cs *CraftingSystem) loadDefaultRecipes() error {
 			RequiredTool:    items.IRON_PICKAXE,
 			RequiredStation: STATION_ANVIL,
 		},
+		// Dimension portal recipe
+		{
+			ID:          "randomland_portal",
+			Name:        "Randomland Portal",
+			Description: "A mystical portal to the chaotic Randomland dimension",
+			Inputs: []RecipeInput{
+				{ItemType: items.IRON_INGOT, Quantity: 1},
+				{ItemType: items.GOLD_INGOT, Quantity: 1},
+				{ItemType: items.DIAMOND, Quantity: 1},
+				{ItemType: items.ANVIL, Quantity: 1}, // Using ANVIL as door substitute
+			},
+			Outputs: []RecipeOutput{
+				{ItemType: items.RANDOMLAND_PORTAL, Quantity: 1},
+			},
+			CraftingTime:    10.0,
+			RequiredTool:    items.IRON_PICKAXE,
+			RequiredStation: STATION_ANVIL,
+		},
 	}
 
 	// Load default recipes

--- a/pkg/dimension/dimension.go
+++ b/pkg/dimension/dimension.go
@@ -1,0 +1,319 @@
+// Package dimension implements the dimension system for TesselBox
+// including the Randomland dimension with chaotic terrain generation
+package dimension
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	"tesselbox/pkg/blocks"
+	"tesselbox/pkg/enemies"
+	"tesselbox/pkg/world"
+)
+
+const (
+	// Randomland dimensions
+	RandomlandWidth  = 500.0
+	RandomlandHeight = 500.0
+	BedrockThickness = 50.0
+	// Generation bounds
+	RandomlandMinY = 50.0  // Top bedrock ends here
+	RandomlandMaxY = 450.0 // Bottom bedrock starts here
+	ReturnPortalX  = 250.0 // Center X
+	ReturnPortalY  = 250.0 // Center Y (in the cavern space)
+)
+
+// DimensionType represents different dimension types
+type DimensionType int
+
+const (
+	Overworld DimensionType = iota
+	Randomland
+)
+
+// Dimension interface for all dimension types
+type Dimension interface {
+	GetWorld() *world.World
+	GetType() DimensionType
+	GetName() string
+	IsGenerated() bool
+}
+
+// RandomlandDimension represents the chaotic Randomland realm
+type RandomlandDimension struct {
+	World         *world.World
+	Type          DimensionType
+	Name          string
+	Generated     bool
+	ReturnPortalX float64
+	ReturnPortalY float64
+	ZombieSpawner *enemies.ZombieSpawner
+	LastVisitTime time.Time
+}
+
+// NewRandomlandDimension creates a new Randomland dimension
+func NewRandomlandDimension() *RandomlandDimension {
+	return &RandomlandDimension{
+		World:         world.NewWorld("randomland"),
+		Type:          Randomland,
+		Name:          "Randomland",
+		Generated:     false,
+		ReturnPortalX: ReturnPortalX,
+		ReturnPortalY: ReturnPortalY,
+		ZombieSpawner: enemies.NewZombieSpawner(nil), // No day/night cycle in randomland
+		LastVisitTime: time.Now(),
+	}
+}
+
+// GetWorld returns the dimension's world
+func (r *RandomlandDimension) GetWorld() *world.World {
+	return r.World
+}
+
+// GetType returns the dimension type
+func (r *RandomlandDimension) GetType() DimensionType {
+	return r.Type
+}
+
+// GetName returns the dimension name
+func (r *RandomlandDimension) GetName() string {
+	return r.Name
+}
+
+// IsGenerated returns whether the dimension has been generated
+func (r *RandomlandDimension) IsGenerated() bool {
+	return r.Generated
+}
+
+// Generate generates the randomland terrain if not already generated
+func (r *RandomlandDimension) Generate() {
+	if r.Generated {
+		return
+	}
+
+	fmt.Println("Generating Randomland dimension...")
+
+	// Set a fixed seed for Randomland (different from overworld)
+	r.World.SetSeed(123456789)
+
+	// Generate bedrock ceiling (top layer)
+	r.generateBedrockLayer(0, BedrockThickness)
+
+	// Generate bedrock floor (bottom layer)
+	r.generateBedrockLayer(RandomlandHeight-BedrockThickness, RandomlandHeight)
+
+	// Generate random blocks in the middle
+	r.generateRandomBlocks()
+
+	// Create return portal at center
+	r.createReturnPortal()
+
+	// Spawn zombies in open spaces
+	r.spawnZombies()
+
+	r.Generated = true
+	fmt.Println("Randomland generation complete!")
+}
+
+// generateBedrockLayer generates a solid layer of bedrock
+func (r *RandomlandDimension) generateBedrockLayer(startY, endY float64) {
+	hexSize := world.HexSize
+	hexWidth := hexSize * 2
+	hexHeight := hexSize * 1.732 // sqrt(3)
+
+	for x := 0.0; x < RandomlandWidth; x += hexWidth * 0.75 {
+		for y := startY; y < endY; y += hexHeight {
+			// Offset every other row
+			actualX := x
+			row := int(y / hexHeight)
+			if row%2 == 1 {
+				actualX += hexWidth * 0.375
+			}
+
+			// Only place if within bounds
+			if actualX < RandomlandWidth {
+				r.World.AddHexagonAt(actualX, y, blocks.BEDROCK)
+			}
+		}
+	}
+}
+
+// generateRandomBlocks fills the middle area with completely random blocks
+func (r *RandomlandDimension) generateRandomBlocks() {
+	hexSize := world.HexSize
+	hexWidth := hexSize * 2
+	hexHeight := hexSize * 1.732
+
+	// All placeable block types (excluding AIR, BEDROCK, and special blocks)
+	placeableBlocks := []blocks.BlockType{
+		blocks.DIRT,
+		blocks.GRASS,
+		blocks.STONE,
+		blocks.SAND,
+		blocks.WATER,
+		blocks.LOG,
+		blocks.LEAVES,
+		blocks.TROPICAL_LOG,
+		blocks.TEMPERATE_LOG,
+		blocks.PINE_LOG,
+		blocks.TROPICAL_LEAVES,
+		blocks.TEMPERATE_LEAVES,
+		blocks.PINE_LEAVES,
+		blocks.COAL_ORE,
+		blocks.IRON_ORE,
+		blocks.GOLD_ORE,
+		blocks.DIAMOND_ORE,
+		blocks.GLASS,
+		blocks.BRICK,
+		blocks.PLANK,
+		blocks.CACTUS,
+		blocks.WORKBENCH,
+		blocks.FURNACE,
+		blocks.ANVIL,
+		blocks.GRAVEL,
+		blocks.SANDSTONE,
+		blocks.OBSIDIAN,
+		blocks.ICE,
+		blocks.SNOW,
+		blocks.TORCH,
+		blocks.CRAFTING_TABLE,
+		blocks.CHEST,
+		blocks.LADDER,
+		blocks.FENCE,
+		blocks.GATE,
+		blocks.DOOR,
+		blocks.WINDOW,
+		blocks.FLOWER,
+		blocks.TALL_GRASS,
+		blocks.MUSHROOM_RED,
+		blocks.MUSHROOM_BROWN,
+		blocks.WOOL,
+		blocks.BOOKSHELF,
+		blocks.JUKEBOX,
+		blocks.NOTE_BLOCK,
+		blocks.PUMPKIN,
+		blocks.MELON,
+		blocks.HAY_BALE,
+		blocks.COBBLESTONE,
+		blocks.MOSSY_COBBLESTONE,
+		blocks.STONE_BRICKS,
+		blocks.CHISELED_STONE,
+	}
+
+	for x := 0.0; x < RandomlandWidth; x += hexWidth * 0.75 {
+		for y := RandomlandMinY; y < RandomlandMaxY; y += hexHeight {
+			// Offset every other row
+			actualX := x
+			row := int((y - RandomlandMinY) / hexHeight)
+			if row%2 == 1 {
+				actualX += hexWidth * 0.375
+			}
+
+			if actualX < RandomlandWidth {
+				// 70% chance to place a block (leave some air pockets)
+				if rand.Float64() < 0.7 {
+					// Pick random block type
+					blockType := placeableBlocks[rand.Intn(len(placeableBlocks))]
+					r.World.AddHexagonAt(actualX, y, blockType)
+				}
+			}
+		}
+	}
+}
+
+// createReturnPortal creates the return portal at the center
+func (r *RandomlandDimension) createReturnPortal() {
+	// Clear area around portal
+	portalX := r.ReturnPortalX
+	portalY := r.ReturnPortalY
+
+	// Create a small safe zone around return portal (3x3 area)
+	for x := portalX - 60; x <= portalX+60; x += 30 {
+		for y := portalY - 50; y <= portalY+50; y += 26 {
+			// Remove any existing blocks
+			r.World.RemoveHexagonAt(x, y)
+		}
+	}
+
+	// Place the return portal block
+	// Use obsidian as base with special properties
+	r.World.AddHexagonAt(portalX, portalY, blocks.OBSIDIAN)
+
+	fmt.Printf("Return portal created at (%.1f, %.1f)\n", portalX, portalY)
+}
+
+// spawnZombies spawns zombies in open spaces
+func (r *RandomlandDimension) spawnZombies() {
+	maxZombies := 20
+	spawnAttempts := 50
+	spawned := 0
+
+	for i := 0; i < spawnAttempts && spawned < maxZombies; i++ {
+		// Random position within the cavern
+		x := RandomlandMinY + rand.Float64()*(RandomlandMaxY-RandomlandMinY)
+		y := BedrockThickness + rand.Float64()*(RandomlandHeight-2*BedrockThickness)
+
+		// Check if position is valid (not in solid blocks, has ground below)
+		hex := r.World.GetHexagonAt(x, y)
+		groundHex := r.World.GetHexagonAt(x, y+30)
+
+		// Valid spawn: air at position, solid ground below
+		if hex == nil && groundHex != nil && groundHex.BlockType != blocks.AIR {
+			// Check distance from return portal (don't spawn too close)
+			dx := x - r.ReturnPortalX
+			dy := y - r.ReturnPortalY
+			distance := dx*dx + dy*dy
+
+			if distance > 10000 { // At least 100 pixels away
+				// Create zombie
+				zombie := enemies.NewZombie(spawned, enemies.ZombieNormal, x, y)
+				r.ZombieSpawner.Zombies = append(r.ZombieSpawner.Zombies, zombie)
+				spawned++
+			}
+		}
+	}
+
+	fmt.Printf("Spawned %d zombies in Randomland\n", spawned)
+}
+
+// GetSpawnPosition returns a safe spawn position in Randomland
+func (r *RandomlandDimension) GetSpawnPosition() (float64, float64) {
+	// Return the return portal location (safe zone)
+	return r.ReturnPortalX, r.ReturnPortalY - 50 // Spawn slightly above portal
+}
+
+// Update updates the dimension (zombies, etc.)
+func (r *RandomlandDimension) Update(playerX, playerY float64, deltaTime float64) {
+	// Create collision function for zombies
+	collisionFunc := func(minX, minY, maxX, maxY float64) bool {
+		nearbyHexagons := r.World.GetNearbyHexagons((minX+maxX)/2, (minY+maxY)/2, 100)
+		for _, hex := range nearbyHexagons {
+			if hex == nil {
+				continue
+			}
+			// Simple AABB collision check
+			if hex.X > minX && hex.X < maxX && hex.Y > minY && hex.Y < maxY {
+				if hex.BlockType != blocks.AIR {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	// Find spawn function
+	spawnFunc := func(x, y float64) (float64, float64) {
+		return r.World.FindSpawnPosition(x, y)
+	}
+
+	// Update zombies (ambient light = 0.5 for randomland - always dim)
+	r.ZombieSpawner.Update(deltaTime, nil, 0.5, collisionFunc, spawnFunc)
+}
+
+// IsNearReturnPortal checks if a position is near the return portal
+func (r *RandomlandDimension) IsNearReturnPortal(x, y float64, tolerance float64) bool {
+	dx := x - r.ReturnPortalX
+	dy := y - r.ReturnPortalY
+	return dx*dx+dy*dy <= tolerance*tolerance
+}

--- a/pkg/dimension/manager.go
+++ b/pkg/dimension/manager.go
@@ -1,0 +1,216 @@
+// Package dimension provides dimension management for teleportation
+// and world switching in TesselBox
+package dimension
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"tesselbox/pkg/player"
+	"tesselbox/pkg/world"
+)
+
+// Manager handles dimension switching and state management
+type Manager struct {
+	CurrentDimension   DimensionType
+	OverworldWorld     *world.World
+	RandomlandDim      *RandomlandDimension
+	PlayerLastOverworldX float64
+	PlayerLastOverworldY float64
+	StoragePath        string
+}
+
+// NewManager creates a new dimension manager
+func NewManager(overworld *world.World, storageDir string) *Manager {
+	return &Manager{
+		CurrentDimension:     Overworld,
+		OverworldWorld:       overworld,
+		RandomlandDim:        nil, // Created on first use
+		PlayerLastOverworldX: 0,
+		PlayerLastOverworldY: 0,
+		StoragePath:          filepath.Join(storageDir, "dimensions"),
+	}
+}
+
+// GetCurrentWorld returns the currently active world
+func (m *Manager) GetCurrentWorld() *world.World {
+	switch m.CurrentDimension {
+	case Randomland:
+		if m.RandomlandDim != nil {
+			return m.RandomlandDim.GetWorld()
+		}
+		return nil
+	default:
+		return m.OverworldWorld
+	}
+}
+
+// GetCurrentDimensionName returns the name of current dimension
+func (m *Manager) GetCurrentDimensionName() string {
+	switch m.CurrentDimension {
+	case Randomland:
+		return "Randomland"
+	default:
+		return "Overworld"
+	}
+}
+
+// IsInRandomland returns true if currently in Randomland
+func (m *Manager) IsInRandomland() bool {
+	return m.CurrentDimension == Randomland
+}
+
+// TeleportToRandomland teleports player to Randomland
+func (m *Manager) TeleportToRandomland(player *player.Player) error {
+	// Save current position in overworld
+	m.PlayerLastOverworldX, m.PlayerLastOverworldY = player.GetCenter()
+
+	// Initialize Randomland if needed
+	if m.RandomlandDim == nil {
+		m.RandomlandDim = NewRandomlandDimension()
+		m.RandomlandDim.Generate()
+	}
+
+	// Switch dimension
+	m.CurrentDimension = Randomland
+
+	// Position player at return portal
+	spawnX, spawnY := m.RandomlandDim.GetSpawnPosition()
+	player.SetPosition(spawnX, spawnY)
+
+	fmt.Printf("Teleported to Randomland! (Return to overworld at %.1f, %.1f)\n",
+		m.PlayerLastOverworldX, m.PlayerLastOverworldY)
+
+	return nil
+}
+
+// TeleportToOverworld teleports player back to overworld
+func (m *Manager) TeleportToOverworld(player *player.Player) error {
+	if m.CurrentDimension != Randomland {
+		return fmt.Errorf("not currently in Randomland")
+	}
+
+	// Switch dimension
+	m.CurrentDimension = Overworld
+
+	// Return player to saved position (or spawn if none saved)
+	player.SetPosition(m.PlayerLastOverworldX, m.PlayerLastOverworldY)
+
+	fmt.Println("Returned to overworld")
+
+	return nil
+}
+
+// CheckReturnPortalProximity checks if player is near return portal in Randomland
+func (m *Manager) CheckReturnPortalProximity(player *player.Player) bool {
+	if m.CurrentDimension != Randomland || m.RandomlandDim == nil {
+		return false
+	}
+
+	px, py := player.GetCenter()
+	return m.RandomlandDim.IsNearReturnPortal(px, py, 60.0) // 60 pixel tolerance
+}
+
+// Update updates the current dimension
+func (m *Manager) Update(player *player.Player, deltaTime float64) {
+	if m.CurrentDimension == Randomland && m.RandomlandDim != nil {
+		px, py := player.GetCenter()
+		m.RandomlandDim.Update(px, py, deltaTime)
+	}
+}
+
+// DimensionState represents save data for dimensions
+type DimensionState struct {
+	RandomlandGenerated bool    `json:"randomland_generated"`
+	ReturnPortalX       float64 `json:"return_portal_x"`
+	ReturnPortalY       float64 `json:"return_portal_y"`
+	LastOverworldX      float64 `json:"last_overworld_x"`
+	LastOverworldY      float64 `json:"last_overworld_y"`
+}
+
+// Save saves dimension state
+func (m *Manager) Save() error {
+	// Ensure storage directory exists
+	if err := os.MkdirAll(m.StoragePath, 0755); err != nil {
+		return fmt.Errorf("failed to create dimension storage: %w", err)
+	}
+
+	state := DimensionState{
+		RandomlandGenerated: m.RandomlandDim != nil && m.RandomlandDim.IsGenerated(),
+		LastOverworldX:      m.PlayerLastOverworldX,
+		LastOverworldY:      m.PlayerLastOverworldY,
+	}
+
+	if m.RandomlandDim != nil {
+		state.ReturnPortalX = m.RandomlandDim.ReturnPortalX
+		state.ReturnPortalY = m.RandomlandDim.ReturnPortalY
+	}
+
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal dimension state: %w", err)
+	}
+
+	filename := filepath.Join(m.StoragePath, "dimension_state.json")
+	if err := os.WriteFile(filename, data, 0644); err != nil {
+		return fmt.Errorf("failed to write dimension state: %w", err)
+	}
+
+	return nil
+}
+
+// Load loads dimension state
+func (m *Manager) Load() error {
+	filename := filepath.Join(m.StoragePath, "dimension_state.json")
+
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// No saved state yet, that's fine
+			return nil
+		}
+		return fmt.Errorf("failed to read dimension state: %w", err)
+	}
+
+	var state DimensionState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return fmt.Errorf("failed to unmarshal dimension state: %w", err)
+	}
+
+	// Restore state
+	m.PlayerLastOverworldX = state.LastOverworldX
+	m.PlayerLastOverworldY = state.LastOverworldY
+
+	// If Randomland was generated, recreate it (but don't regenerate terrain)
+	if state.RandomlandGenerated {
+		m.RandomlandDim = NewRandomlandDimension()
+		m.RandomlandDim.ReturnPortalX = state.ReturnPortalX
+		m.RandomlandDim.ReturnPortalY = state.ReturnPortalY
+		// Mark as generated so we don't regenerate
+		m.RandomlandDim.Generated = true
+	}
+
+	return nil
+}
+
+// CanTeleportToRandomland checks if player is on a portal block in overworld
+func (m *Manager) CanTeleportToRandomland(player *player.Player) bool {
+	if m.CurrentDimension != Overworld {
+		return false
+	}
+
+	// Check if standing on a portal block
+	px, py := player.GetCenter()
+	world := m.OverworldWorld
+
+	hex := world.GetHexagonAt(px, py)
+	if hex == nil {
+		return false
+	}
+
+	// Check if it's a portal block (we'll add RANDOMLAND_PORTAL type)
+	// For now, use OBSIDIAN as a placeholder
+	return hex.BlockType == 98 // RANDOMLAND_PORTAL type number
+}

--- a/pkg/items/items.go
+++ b/pkg/items/items.go
@@ -68,6 +68,7 @@ const (
 	DIAMOND_LEGGINGS
 	DIAMOND_BOOTS
 	ANVIL
+	RANDOMLAND_PORTAL
 )
 
 // ItemProperties defines the properties of an item type
@@ -171,6 +172,7 @@ var ItemTypeMap = map[string]ItemType{
 	"diamond_leggings":   DIAMOND_LEGGINGS,
 	"diamond_boots":      DIAMOND_BOOTS,
 	"anvil":              ANVIL,
+	"randomland_portal":  RANDOMLAND_PORTAL,
 }
 
 var ItemDefinitions = map[ItemType]*ItemProperties{
@@ -480,6 +482,17 @@ var ItemDefinitions = map[ItemType]*ItemProperties{
 		IsTool:      false,
 		IsPlaceable: true,
 		BlockType:   "anvil",
+	},
+	RANDOMLAND_PORTAL: {
+		ID:          RANDOMLAND_PORTAL,
+		Name:        "Randomland Portal",
+		IconColor:   color.RGBA{147, 0, 211, 255}, // Purple
+		Description: "A mystical portal to the chaotic Randomland dimension",
+		StackSize:   1,
+		Durability:  -1,
+		IsTool:      false,
+		IsPlaceable: true,
+		BlockType:   "randomland_portal",
 	},
 	WOODEN_PICKAXE: {
 		ID:          WOODEN_PICKAXE,


### PR DESCRIPTION
- Add new Randomland dimension with chaotic terrain generation
- Create bedrock ceiling/floor with completely randomized blocks between
- Implement portal block (craftable at anvil with iron+gold+diamond+anvil)
- Add dimension manager for teleportation between overworld and randomland
- Spawn zombies in Randomland open spaces
- Return portal always at center for easy exit
- Save/load dimension state persistently
- Integrate portal prompts and dimension switching with 'E' key